### PR TITLE
Fix PED file writing on cloud platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 1. Added a new option to the samplesheet (`msi`). This option takes a boolean to indicate whether or not the MSI status of the sample should be checked. A baseline should be provided using the `--msi_baseline` parameter to run MSI calling.
 2. The Multiqc module now generates branded reports.
 
+## Fixes
+
+1. Fixed PED file writing on cloud platforms
+
 ## v1.10.1 - Mighty Mechelen - [May 26 2025]
 
 ## Fixes

--- a/lib/Pedigree.groovy
+++ b/lib/Pedigree.groovy
@@ -52,9 +52,10 @@ class Pedigree {
 
     public Map<String,Path> writePeds(WorkflowMetadata workflow) {
         def Map<String,Path> returnMap = [:]
-        Nextflow.file("${workflow.workDir}/peds_${workflow.runName}").mkdir()
+        def String workdir = workflow.workDir.toUri()
+        Nextflow.file("${workdir}/peds_${workflow.runName}").mkdir()
         pedigrees.each { String family, List<PedigreeEntry> entries ->
-            def Path pedFile = Nextflow.file("${workflow.workDir}/peds_${workflow.runName}/${family}.ped")
+            def Path pedFile = Nextflow.file("${workdir}/peds_${workflow.runName}/${family}.ped")
             pedFile.text = entries.collect { it.toLine() }.join("")
             returnMap[family] = pedFile
         }


### PR DESCRIPTION
Changed the base of the full path to the URI of the work directory instead of the raw string of the work directory