### PR TITLE
fix sort order of process_beds

### DIFF
--- a/modules/local/process_beds/main.nf
+++ b/modules/local/process_beds/main.nf
@@ -27,8 +27,8 @@ process PROCESS_BEDS {
     """
     ${unzip} ${bed} \\
         | grep ${args} \\
-        | bedtools sort -faidx ${fai} \\
         | bedtools merge ${args2} \\
+        | bedtools sort -faidx ${fai} \\
         ${intersect} \\
         > ${prefix}.bed
 


### PR DESCRIPTION
A small fix to prevent a SIGPIPE when the input of PROCESS_BEDS is unsorted