### PR TITLE
Fix quantize labels in mosdepth on GCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.13.0 - Luxurious Luik - [March 23 2026]
+## v1.13.0 - Luxurious Luik - [April 28 2026]
 
 ## New features
 
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 1. Fixed `wrong number of arguments` error when the `family` field was missing from the samplesheet
 2. Bumped `nf-ped` to correctly work on cloud systems
+3. Set environment variables for mosdepth directly in the process instead of in the config
 
 ## v1.12.0 - Noble Namur - [Feb 3 2026]
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -373,10 +373,3 @@ process {
         }
     }
 }
-
-env {
-    // Add env variables for MOSDEPTH
-    MOSDEPTH_Q0 = 'NO_COVERAGE'
-    MOSDEPTH_Q1 = 'LOW_COVERAGE'
-    MOSDEPTH_Q2 = 'CALLABLE'
-}

--- a/modules.json
+++ b/modules.json
@@ -123,7 +123,7 @@
                     },
                     "mosdepth": {
                         "branch": "master",
-                        "git_sha": "6832b69ef7f98c54876d6436360b6b945370c615",
+                        "git_sha": "171cec903f5993a3b28662582bbb349fc8959d35",
                         "installed_by": ["modules"]
                     },
                     "msisensorpro/pro": {

--- a/modules/nf-core/mosdepth/main.nf
+++ b/modules/nf-core/mosdepth/main.nf
@@ -3,13 +3,14 @@ process MOSDEPTH {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/00/00d32b53160c26794959da7303ee6e2107afd4d292060c9f287b0af1fddbd847/data' :
         'community.wave.seqera.io/library/mosdepth_htslib:0f58993cb6d93294'}"
 
     input:
     tuple val(meta),  path(bam), path(bai), path(bed)
     tuple val(meta2), path(fasta)
+    val(quantize_labels)
 
     output:
     tuple val(meta), path('*.global.dist.txt')      , emit: global_txt
@@ -34,6 +35,12 @@ process MOSDEPTH {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference = fasta ? "--fasta ${fasta}" : ""
     def interval = bed ? "--by ${bed}" : ""
+    def quantize_env_vars = []
+    if (quantize_labels instanceof List && quantize_labels.size() > 0) {
+        quantize_labels.eachWithIndex { label, index ->
+            quantize_env_vars << "MOSDEPTH_Q${index}=${label}"
+        }
+    }
     if (bed && (args.contains("--by") || args.contains("-b "))) {
         error "'--by' can only be specified once when running mosdepth! Either remove input BED file definition or remove '--by' from 'ext.args' definition"
     }
@@ -42,7 +49,7 @@ process MOSDEPTH {
     }
 
     """
-    mosdepth \\
+    ${quantize_env_vars.join(" ")} mosdepth \\
         --threads $task.cpus \\
         $interval \\
         $reference \\

--- a/modules/nf-core/mosdepth/meta.yml
+++ b/modules/nf-core/mosdepth/meta.yml
@@ -11,7 +11,8 @@ tools:
         Fast BAM/CRAM depth calculation for WGS, exome, or targeted sequencing.
       documentation: https://github.com/brentp/mosdepth
       doi: 10.1093/bioinformatics/btx699
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:mosdepth
 input:
   - - meta:
@@ -44,6 +45,12 @@ input:
         description: Reference genome FASTA file
         pattern: "*.{fa,fasta}"
         ontologies: []
+  - quantize_labels:
+      type: list
+      description: |
+        List of labels for quantized coverage bins, e.g. [ "NO_COVERAGE", "LOW_COVERAGE", "MEDIUM_COVERAGE", "HIGH_COVERAGE" ]
+        The first value will be assigned to the `MOSDEPTH_Q0` environment variable, the second to `MOSDEPTH_Q1`, and so on.
+        These can then be used in the `--quantize` option of mosdepth to assign labels to quantized coverage bins.
 output:
   global_txt:
     - - meta:
@@ -64,7 +71,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.summary.txt":
           type: file
-          description: Text file with summary mean depths per chromosome and regions
+          description: Text file with summary mean depths per chromosome and
+            regions
           pattern: "*.{summary.txt}"
           ontologies: []
   regions_txt:
@@ -163,8 +171,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.thresholds.bed.gz":
           type: file
-          description: BED file with the number of bases in each region that are covered
-            at or above each threshold
+          description: BED file with the number of bases in each region that are
+            covered at or above each threshold
           pattern: "*.{thresholds.bed.gz}"
           ontologies: []
   thresholds_csi:
@@ -186,9 +194,8 @@ output:
           type: string
           description: The tool name
       - "mosdepth --version | sed 's/mosdepth //g'":
-          type: string
+          type: eval
           description: The command used to generate the version of the tool
-
 topics:
   versions:
     - - ${task.process}:
@@ -198,7 +205,7 @@ topics:
           type: string
           description: The tool name
       - "mosdepth --version | sed 's/mosdepth //g'":
-          type: string
+          type: eval
           description: The command used to generate the version of the tool
 authors:
   - "@joseespinosa"

--- a/modules/nf-core/mosdepth/tests/main.nf.test
+++ b/modules/nf-core/mosdepth/tests/main.nf.test
@@ -24,6 +24,7 @@ nextflow_process {
                     []
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }
@@ -52,6 +53,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }
@@ -83,6 +85,7 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
                 ]
+                input[2] = []
                 """
             }
         }
@@ -114,6 +117,7 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
                 ]
+                input[2] = []
                 """
             }
         }
@@ -142,6 +146,7 @@ nextflow_process {
                     []
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }
@@ -170,6 +175,7 @@ nextflow_process {
                     []
                 ]
                 input[1] = [[],[]]
+                input[2] = ['NO_COVERAGE', 'LOW_COVERAGE', 'MEDIUM_COVERAGE', 'HIGH_COVERAGE']
                 """
             }
         }
@@ -198,6 +204,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }
@@ -226,6 +233,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }
@@ -252,6 +260,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
                 ]
                 input[1] = [[],[]]
+                input[2] = []
                 """
             }
         }

--- a/modules/nf-core/mosdepth/tests/main.nf.test.snap
+++ b/modules/nf-core/mosdepth/tests/main.nf.test.snap
@@ -234,11 +234,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:06:13.219131",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:06:13.219131"
+        }
     },
     "homo_sapiens - cram, crai, bed": {
         "content": [
@@ -415,11 +415,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:22:14.011309",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:14.011309"
+        }
     },
     "homo_sapiens - bam, bai, [] - quantized": {
         "content": [
@@ -491,7 +491,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz:md5,f037c215449d361112efc10108fcc17c"
+                        "test.quantized.bed.gz:md5,02fcfd09862c63b717e519abb4897e2e"
                     ]
                 ],
                 "9": [
@@ -500,7 +500,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz.csi:md5,c0a3176a59010639455a4aefb3f247ef"
+                        "test.quantized.bed.gz.csi:md5,7e0413e355b920bafe8800e670e26547"
                     ]
                 ],
                 "global_txt": [
@@ -539,7 +539,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz:md5,f037c215449d361112efc10108fcc17c"
+                        "test.quantized.bed.gz:md5,02fcfd09862c63b717e519abb4897e2e"
                     ]
                 ],
                 "quantized_csi": [
@@ -548,7 +548,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz.csi:md5,c0a3176a59010639455a4aefb3f247ef"
+                        "test.quantized.bed.gz.csi:md5,7e0413e355b920bafe8800e670e26547"
                     ]
                 ],
                 "regions_bed": [
@@ -584,11 +584,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-27T17:07:22.405843995",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:22.818082"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "homo_sapiens - bam, bai, bed": {
         "content": [
@@ -765,11 +765,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:22:04.449943",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:04.449943"
+        }
     },
     "homo_sapiens - bam, bai, [] - window": {
         "content": [
@@ -946,11 +946,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:22:18.435089",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:18.435089"
+        }
     },
     "homo_sapiens - bam, bai, []": {
         "content": [
@@ -1091,11 +1091,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:21:59.785829",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:21:59.785829"
+        }
     },
     "homo_sapiens - cram, crai, []": {
         "content": [
@@ -1236,11 +1236,11 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:22:09.294766",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:09.294766"
+        }
     },
     "homo_sapiens - bam, bai, bed - thresholds": {
         "content": [
@@ -1441,10 +1441,10 @@
                 ]
             }
         ],
+        "timestamp": "2025-09-23T13:22:27.300204",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-09-23T13:22:27.300204"
+        }
     }
 }

--- a/subworkflows/local/cram_prepare_samtools_bedtools/main.nf
+++ b/subworkflows/local/cram_prepare_samtools_bedtools/main.nf
@@ -138,7 +138,8 @@ workflow CRAM_PREPARE_SAMTOOLS_BEDTOOLS {
 
     MOSDEPTH(
         ch_mosdepth_input,
-        ch_fasta
+        ch_fasta,
+        ['NO_COVERAGE', 'LOW_COVERAGE', 'CALLABLE']
     )
     def ch_mosdepth_reports = MOSDEPTH.out.summary_txt
         .mix(


### PR DESCRIPTION
This pull request removes the use of the `env` config option and adds an input to the mosdepth that is a list of the quantize labels to use instead